### PR TITLE
Sortieren durch auswahl

### DIFF
--- a/Script/setl.tex
+++ b/Script/setl.tex
@@ -959,7 +959,7 @@ Das Programm produziert die folgende Ausgabe:
            return [];
         }
         m := min(l);
-        return [ m ] + minSort( [ x : x in l | x != m ] );
+        return [x: x in l| x == m] + minSort( [ x : x in l | x != m ] );
     };
 
     l := [ 13, 5, 13, 7, 2, 4 ];


### PR DESCRIPTION
Sortieren durch Auswahl funktioniert jetzt mit doppelten Elementen in einer Liste.