### PR TITLE
fix limits.tex

### DIFF
--- a/Lecture-Notes/limits.tex
+++ b/Lecture-Notes/limits.tex
@@ -221,7 +221,7 @@ This notation is read as ``\emph{evaluation of $n(a_1, \cdots, a_k)$ \blue{diver
 \noindent
 The \blue{halting problem} \index{halting problem} for \textsl{TypeScript} functions is the question whether there is a
 \textsl{TypeScript} function \\[0.2cm]
-\hspace*{1.3cm} \texttt{def stops($t$,$\;a$) \{ } \\
+\hspace*{1.3cm} \texttt{function stops($t$,$\;a$) \{ } \\
 \hspace*{2.3cm} $\vdots$ \\
 \hspace*{1.3cm} $\}$
 \\[0.2cm] 


### PR DESCRIPTION
I noticed that the `stops` function is written in Python, although it should probably be written in TypeScript.