### PR TITLE
docker hotfix for macs: force nodejs version to be at least 25

### DIFF
--- a/TypeScript/Dockerfile
+++ b/TypeScript/Dockerfile
@@ -14,7 +14,7 @@ USER ${NB_UID}
 # Switch back to jovyan to avoid accidental container runs as root
 # Add permanent mamba/pip/conda installs, data files, other user libs here
 # e.g., RUN pip install --no-cache-dir flake8
-RUN conda install -c conda-forge nodejs
+RUN conda install -c conda-forge "nodejs>=25"
 RUN mamba install 
 RUN npm init -y
 RUN npm install -g tslab


### PR DESCRIPTION
Hi,

today we noticed that some macs default back to node 11 for some reason.
Because of this, the image build fails. To fix this, we pinned the node version to at least 25.

Kind regards,
Simon