### PR TITLE
clarified directions in the Japanes-Z3-Frame riddle

### DIFF
--- a/TypeScript/Chapter-5/Japanese-Z3-Frame.ipynb
+++ b/TypeScript/Chapter-5/Japanese-Z3-Frame.ipynb
@@ -190,10 +190,10 @@
    "metadata": {},
    "source": [
     "The function `transition` takes 13 parameters:\n",
-    "* `Pa` is the number of policemen on the western shore before the boat crosses the river,\n",
-    "  while `Pb` is the number of policemen on the western shore after the crossing.\n",
-    "* `Va` is the number of villains on the western shore before the boat crosses the river,\n",
-    "  while `vb` is the number of villains on the western shore after the crossing.\n",
+    "* `Pa` is the number of policemen on the western (left) shore before the boat crosses the river,\n",
+    "  while `Pb` is the number of policemen on the eastern (right) after the crossing.\n",
+    "* `Va` is the number of villains on the western (left) shore before the boat crosses the river,\n",
+    "  while `vb` is the number of villains on the eastern (right) shore after the crossing.\n",
     "* $\\vdots$\n",
     "* `i` is the number of the crossing.  For the first crossing, $\\texttt{i} = 0$.\n",
     "\n",
@@ -286,9 +286,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "console.time(\"findSolution\"); \n",


### PR DESCRIPTION
Hi,

ich hab glaube ich einen fehler in der heutigen Aufgabenstellung gefunden.
Da stand zweimal `western`.
Ich hab eins davon zu `eastern` geändert und rechts/links in klammern dazugefügt.

VG Simon